### PR TITLE
Pass chained driver instance to video_thread()

### DIFF
--- a/io.h
+++ b/io.h
@@ -323,7 +323,7 @@ static inline void video_copy_2d(void* dst, size_t dstpitch, const void* src, si
 // ask for either initialization, vsync, shaders, nor screenshots.
 // Instead, they must be called on this object; the calls will be passed on to the real driver.
 //Due to its special properties, it is not included in the list of drivers.
-video* video_create_thread();
+video* video_create_thread(video* chain);
 
 extern const driver_video video_d3d9_desc;
 extern const driver_video video_ddraw_desc;

--- a/main.cpp
+++ b/main.cpp
@@ -153,9 +153,7 @@ bool try_set_interface_video(unsigned int id, uintptr_t windowhandle,
 	vid=device;
 	if (config.video_thread)
 	{
-		video* outer=video_create_thread();
-		outer->set_chain(vid);
-		vid=outer;
+		vid = video_create_thread(vid);
 	}
 	vid->initialize();
 	vid->set_source(videowidth*config.video_scale, videoheight*config.video_scale, videodepth);

--- a/videothreader.cpp
+++ b/videothreader.cpp
@@ -277,7 +277,7 @@ public://since this entire file is private, making it public inside here does no
 		this->lock->unlock();
 	}
 	
-	video_thread()
+	video_thread(video* chain)
 	{
 		this->src_depth=0;
 		this->src_bpp=0;
@@ -303,6 +303,8 @@ public://since this entire file is private, making it public inside here does no
 		this->buf_temp.bufsize=0;
 		this->buf_last.data=NULL;
 		this->buf_last.bufsize=0;
+
+		this->next = chain;
 		
 		thread_create(bind_this(&video_thread::threadproc));
 	}
@@ -332,7 +334,7 @@ public://since this entire file is private, making it public inside here does no
 
 }
 
-video* video_create_thread()
+video* video_create_thread(video* chain)
 {
-	return new video_thread();
+	return new video_thread(chain);
 }


### PR DESCRIPTION
Fixes uninitialized use of this->next
